### PR TITLE
Add configuration for selling masks first

### DIFF
--- a/SellFromTerminal/Plugin.cs
+++ b/SellFromTerminal/Plugin.cs
@@ -55,6 +55,7 @@ namespace SellFromTerminal
 		public static ConfigEntry<bool> ConfigCanSellShotgunAndShells;
 		public static ConfigEntry<bool> ConfigCanSellGifts;
 		public static ConfigEntry<bool> ConfigCanSellPickles;
+		public static ConfigEntry<bool> ConfigPrioritizeSellingMasks;
 		public static ConfigEntry<int> ConfigExactAmountAllowance;
 
 		private void LoadConfigs() {
@@ -73,6 +74,11 @@ namespace SellFromTerminal
 											   true,
 											   "Whether or not to allow the 'Jar of Pickles' item to be sold");
 
+			ConfigPrioritizeSellingMasks = Config.Bind("Priority Selling",
+													   "PrioritizeSellingMasks",
+													   false,
+													   "Whether or not the mask items should have priority in selling.");
+			
 			ConfigExactAmountAllowance = Config.Bind("Misc",
 													 "ExactAmountAllowance",
 													 0,


### PR DESCRIPTION
Some people prefer selling mask items first because they produce random sinister sounds.

This also adds an overall system for proritizing items, but is only used for the masks currently.

The approach for priority can lead to overselling if the priority value is bigger than current quota. That is the only caveat I can think of with this config, and for masks specifically, you will rarely have that many masks. Something else would need to be added on top of this to go adress the issue.