### PR TITLE
Fixed Small Mistakes

### DIFF
--- a/SellFromTerminal/Patches/TerminalPatch.cs
+++ b/SellFromTerminal/Patches/TerminalPatch.cs
@@ -242,7 +242,7 @@ namespace SellFromTerminal.Patches
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.RunTerminalEvents))]
-		public static void RunTerminalEvents(ref TerminalNode node) {
+		public static void RunTerminalEvents(TerminalNode node) {
 			if (node.terminalEvent == "sellAll") {
 				NetworkHandler.Instance.SellAllScrapServerRpc();
 			}

--- a/SellFromTerminal/Patches/TerminalPatch.cs
+++ b/SellFromTerminal/Patches/TerminalPatch.cs
@@ -20,7 +20,7 @@ namespace SellFromTerminal.Patches
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.Awake))]
-		public static void AddTerminalNodes(Terminal __instance) {
+		public static void AddTerminalNodes(ref Terminal __instance) {
 			if (patchedTerminal) {
 				return;
 			}
@@ -170,20 +170,18 @@ namespace SellFromTerminal.Patches
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.TextPostProcess))]
-		public static string ProcessCustomText(string __result) {
+		public static void ProcessCustomText(ref string __result) {
 			__result = __result.Replace("[numScrap]", ScrapHelpers.CountAllScrapInShip().ToString());
 			__result = __result.Replace("[sellScrapFor]", sellScrapFor.ToString());
 			__result = __result.Replace("[numScrapSold]", numScrapSold.ToString());
 			__result = __result.Replace("[totalScrapValue]", ScrapHelpers.GetTotalScrapValueInShip().ToString());
 			string companyBuyingRateWarning = StartOfRound.Instance.companyBuyingRate == 1f ? "" : $"\n\nWARNING: Company buying rate is currently at {StartOfRound.Instance.companyBuyingRate:P0}\n\n";
 			__result = __result.Replace("[companyBuyingRateWarning]", companyBuyingRateWarning);
-
-			return __result;
 		}
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.ParsePlayerSentence))]
-		public static void SetSellScrapForHack(TerminalNode __result, Terminal __instance) {
+		public static void SetSellScrapForHack(ref TerminalNode __result, ref Terminal __instance) {
 			if (__result == null) {
 				return;
 			}
@@ -201,7 +199,7 @@ namespace SellFromTerminal.Patches
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.ParsePlayerSentence))]
-		public static TerminalNode TryParseSellAmount(TerminalNode __result, Terminal __instance) {
+		public static void TryParseSellAmount(ref TerminalNode __result, ref Terminal __instance) {
 			string terminalInput = __instance.screenText.text.Substring(__instance.screenText.text.Length - __instance.textAdded);
 
 			Regex regex = new Regex(@"^sell (\d+$)$");
@@ -209,34 +207,35 @@ namespace SellFromTerminal.Patches
 			if (match.Success) {
 				sellScrapFor = Convert.ToInt32(match.Groups[1].Value);
 				if (sellScrapFor > 0) {
-					return sellAmountNode;
+                    __result = sellAmountNode;
 				}
 			}
-
-			return __result;
 		}
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.ParsePlayerSentence))]
-		public static TerminalNode TryReturnSpecialNodes(TerminalNode __result, Terminal __instance) {
-			if (__result.name == "sellQuota" && TimeOfDay.Instance.profitQuota - TimeOfDay.Instance.quotaFulfilled <= 0) {
-				return specialQuotaAlreadyMetNode;
+		public static void TryReturnSpecialNodes(ref TerminalNode __result) {
+            if (__result == null)
+            {
+                return;
+            }
+
+            if (__result.name == "sellQuota" && TimeOfDay.Instance.profitQuota - TimeOfDay.Instance.quotaFulfilled <= 0) {
+                __result = specialQuotaAlreadyMetNode;
 			}
 
 			if ((__result.name == "sellQuota" || __result.name == "sellAmount") && sellScrapFor > ScrapHelpers.GetTotalScrapValueInShip()) {
-				return specialNotEnoughScrapNode;
+                __result = specialNotEnoughScrapNode;
 			}
 
 			if ((__result.name == "sellQuota" || __result.name == "sellAmount" || __result.name == "sellAll") && (StartOfRound.Instance.currentLevel.levelID != 3 || StartOfRound.Instance.inShipPhase) /* Company building */) {
-				return specialCanOnlySellAtCompanyNode;
+                __result = specialCanOnlySellAtCompanyNode;
 			}
-
-			return __result;
 		}
 
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(Terminal.RunTerminalEvents))]
-		public static void RunTerminalEvents(TerminalNode node) {
+		public static void RunTerminalEvents(ref TerminalNode node) {
 			if (node.terminalEvent == "sellAll") {
 				NetworkHandler.Instance.SellAllScrapServerRpc();
 			}


### PR DESCRIPTION
- Fixed HarmonyPatches returning the value instead of setting `__result`
- Fixed an error when typing in a security door/turret/landmine terminal code which causes the typed code to not automatically disappear.